### PR TITLE
fix error when using a string as payload and jwt type in the header

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,11 @@ function makeError(opts) {
   return merge(new Error(opts.message||opts.code), opts);
 }
 
-function jwsSecuredInput(header, payload) {
+function jwsSecuredInput(header, payload, opts) {
   const encodedHeader = base64url(toString(header));
-  const encodedPayload = base64url(toString(payload));
+  const encodedPayload = header.typ === 'JWT' || opts.json
+    ? base64url(JSON.stringify(payload))
+    : base64url(toString(payload));
   return util.format('%s.%s', encodedHeader, encodedPayload);
 }
 
@@ -39,7 +41,7 @@ function jwsSign(opts) {
   const payload = opts.payload;
   const secretOrKey = opts.secret || opts.privateKey;
   const algo = jwa(header.alg);
-  const securedInput = jwsSecuredInput(header, payload);
+  const securedInput = jwsSecuredInput(header, payload, opts);
   const signature = algo.sign(securedInput, secretOrKey);
   return util.format('%s.%s', securedInput, signature);
 }

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -221,6 +221,13 @@ test('jws.decode: with a bogus header ', function (t) {
   t.end();
 });
 
+test('jws.decode: with JWS type in header and string payload', function (t) {
+  const payload = 'hi';
+  const sig = jws.sign({ header: { alg: 'hs256', typ: 'JWT'}, payload: payload, secret: 'shhh' });
+  t.same(jws.decode(sig).payload, payload);
+  t.end();
+});
+
 test('jws.isValid', function (t) {
   const valid = jws.sign({ header: { alg: 'hs256' }, payload: 'hi', secret: 'shhh' });
   const invalid = (function(){


### PR DESCRIPTION
Fix an error when using a string as payload and specifying the type "jwt" in the header. At the moment, when the payload is serialized, it is done based in its type, but when is deserialized it checks the header and options to see if it must be parsed as JSON. As a result, it tries to deserialize a normal string as a json string and throws a parse exception. For fixing it, I modified the securedInput function to do the same check that the jwsDecode function.