### PR TITLE
Update jwsDecode

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function jwsDecode(jwsSig, opts) {
   if (!header)
     return null;
   var payload = payloadFromJWS(jwsSig);
-  if (header.typ === 'JWT' || opts.json)
+  if (!header.typ || header.typ === 'JWT' || opts.json)
     payload = JSON.parse(payload);
   return {
     header: header,


### PR DESCRIPTION
added condition to re parse string to json when header.typ is not present, basing on spec:
5.1.  "typ" (Type) Header Parameter

The typ (type) Header Parameter defined by [JWS] and [JWE] is used by JWT applications to declare the MIME Media Type [IANA.MediaTypes] of this complete JWT. This is intended for use by the JWT application when values that are not JWTs could also be present in an application data structure that can contain a JWT object; the application can use this value to disambiguate among the different kinds of objects that might be present. It will typically not be used by applications when it is already known that the object is a JWT. This parameter is ignored by JWT implementations; any processing of this parameter is performed by the JWT application. If present, it is RECOMMENDED that its value be JWT to indicate that this object is a JWT. While media type names are not case-sensitive, it is RECOMMENDED that JWT always be spelled using uppercase characters for compatibility with legacy implementations. Use of this Header Parameter is OPTIONAL.

Parameter is OPTIONAL and " It will typically not be used by applications when it is already known that the object is a JWT. This parameter is ignored by JWT implementations;"