### PR TITLE
adding equals sign into validation regex

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -5,7 +5,7 @@ const jwa = require('jwa');
 const Stream = require('stream');
 const toString = require('./tostring');
 const util = require('util');
-const JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/;
+const JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-=_]+?\.([a-zA-Z0-9\-_]+)?$/;
 
 function isObject(thing) {
   return Object.prototype.toString.call(thing) === '[object Object]';


### PR DESCRIPTION
[closes #22]

This will allow tokens base64 encoded tokens to be validated as legit. Without the allowance of the equals sign, base64 encoding that requires padding is rejected. The spec appears to allow for base64 encoded tokens, though it encourages base64url encoding (which does not produce padding).