### PR TITLE
perf(decode) make selecting jws parts faster

### DIFF
--- a/lib/_decode.js
+++ b/lib/_decode.js
@@ -1,0 +1,71 @@
+/* global Buffer, module */
+/* jshint laxbreak:true */
+
+const toString = require('./tostring');
+
+const JWS_REGEX = (function () {
+  const BASE64_PART = /[a-zA-Z0-9\-_]+/;
+
+  return new RegExp(
+    '^'
+    + BASE64_PART.source
+    + '\\.'
+    + BASE64_PART.source
+    + '\\.'
+    + '(' + BASE64_PART.source + ')?'
+    + '$'
+  );
+})();
+
+function tryParse(thing) {
+  try { return JSON.parse(thing); }
+  catch (e) { return undefined; }
+}
+
+function utf8(input) {
+  const result = new Buffer(input, 'base64').toString('utf8');
+  return result;
+}
+
+function jwsParts(jws) {
+  jws = toString(jws);
+
+  if (!JWS_REGEX.test(jws)) {
+    return null;
+  }
+
+  const parts = jws.split('.');  
+  return parts;
+}
+
+function headerFromParts(parts) {
+  var header = parts[0];
+  header = utf8(header);
+  header = tryParse(header);
+  return header;
+}
+
+function payloadFromParts(parts, json) {
+  var payload = parts[1];
+  payload = utf8(payload);
+
+  if (json) {
+    payload = JSON.parse(payload);
+  }
+
+  return payload;
+}
+
+function securedInputFromParts(parts) {
+  return parts[0] + '.' + parts[1];
+}
+
+function signatureFromParts(parts) {
+  return parts[2];
+}
+
+module.exports = jwsParts;
+module.exports.header = headerFromParts;
+module.exports.payload = payloadFromParts;
+module.exports.input = securedInputFromParts;
+module.exports.signature = signatureFromParts;

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -1,44 +1,15 @@
 /*global module*/
-const base64url = require('base64url');
 const DataStream = require('./data-stream');
 const jwa = require('jwa');
 const Stream = require('stream');
-const toString = require('./tostring');
 const util = require('util');
-const JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/;
 
-function isObject(thing) {
-  return Object.prototype.toString.call(thing) === '[object Object]';
-}
-
-function safeJsonParse(thing) {
-  if (isObject(thing))
-    return thing;
-  try { return JSON.parse(thing); }
-  catch (e) { return undefined; }
-}
-
-function headerFromJWS(jwsSig) {
-  const encodedHeader = jwsSig.split('.', 1)[0];
-  return safeJsonParse(base64url.decode(encodedHeader, 'binary'));
-}
-
-function securedInputFromJWS(jwsSig) {
-  return jwsSig.split('.', 2).join('.');
-}
-
-function signatureFromJWS(jwsSig) {
-  return jwsSig.split('.')[2];
-}
-
-function payloadFromJWS(jwsSig, encoding) {
-  encoding = encoding || 'utf8';
-  const payload = jwsSig.split('.')[1];
-  return base64url.decode(payload, encoding);
-}
+const _decode = require('./_decode');
 
 function isValidJws(string) {
-  return JWS_REGEX.test(string) && !!headerFromJWS(string);
+  const parts = _decode(string);
+  const valid = !!(parts && _decode.header(parts));
+  return valid;
 }
 
 function jwsVerify(jwsSig, algorithm, secretOrKey) {
@@ -47,33 +18,38 @@ function jwsVerify(jwsSig, algorithm, secretOrKey) {
     err.code = "MISSING_ALGORITHM";
     throw err;
   }
-  jwsSig = toString(jwsSig);
-  const signature = signatureFromJWS(jwsSig);
-  const securedInput = securedInputFromJWS(jwsSig);
+
+  const parts = _decode(jwsSig);
+  if (!parts) {
+    return false;
+  }
+
+  const signature = _decode.signature(parts);
+  const securedInput = _decode.input(parts);
   const algo = jwa(algorithm);
   return algo.verify(securedInput, signature, secretOrKey);
 }
 
 function jwsDecode(jwsSig, opts) {
-  opts = opts || {};
-  jwsSig = toString(jwsSig);
+  const parts = _decode(jwsSig);
 
-  if (!isValidJws(jwsSig))
+  if (!parts) {
     return null;
+  }
 
-  const header = headerFromJWS(jwsSig);
+  const header = _decode.header(parts);
 
-  if (!header)
+  if (!header) {
     return null;
+  }
 
-  var payload = payloadFromJWS(jwsSig);
-  if (header.typ === 'JWT' || opts.json)
-    payload = JSON.parse(payload, opts.encoding);
+  const payload = _decode.payload(parts, header.typ === 'JWT' || (opts && opts.json));
+  const signature = _decode.signature(parts);
 
   return {
     header: header,
     payload: payload,
-    signature: signatureFromJWS(jwsSig)
+    signature: signature
   };
 }
 


### PR DESCRIPTION
* avoid searching/splitting the input string many times
* 10-20% faster hmac verifications on small inputs

micro-optimizing surely, but it's a pretty small space, and might as well limit the impact as much as possible if you ask me

Runs of `jws.verify(jwsWithSig, 'hs256', 'lolol');` goes from ~115kHz to ~136kHz on my laptop.