### PR TITLE
sign: dont convert input buffers to utf8 strings

### DIFF
--- a/lib/sign-stream.js
+++ b/lib/sign-stream.js
@@ -3,13 +3,13 @@ var base64url = require('base64url');
 var DataStream = require('./data-stream');
 var jwa = require('jwa');
 var Stream = require('stream');
-var toString = require('./tostring');
+var toBuffer = require('./to-buffer');
 var util = require('util');
 
 function jwsSecuredInput(header, payload, encoding) {
   encoding = encoding || 'utf8';
-  var encodedHeader = base64url(toString(header), 'binary');
-  var encodedPayload = base64url(toString(payload), encoding);
+  var encodedHeader = base64url(toBuffer(header));
+  var encodedPayload = base64url(toBuffer(payload, encoding));
   return util.format('%s.%s', encodedHeader, encodedPayload);
 }
 

--- a/lib/to-buffer.js
+++ b/lib/to-buffer.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var Buffer = require('safe-buffer').Buffer;
+
+module.exports = function toBuffer(val, encoding) {
+	if (Buffer.isBuffer(val)) {
+		return val;
+	}
+	if (typeof val === 'string') {
+		return Buffer.from(val, encoding || 'utf8');
+	}
+	if (typeof val === 'number') {
+		// This won't work for very large or very small numbers, but is consistent
+		// with previous behaviour at least
+		val = val.toString();
+		return Buffer.from(val, 'utf8');
+	}
+	return Buffer.from(JSON.stringify(val), 'utf8');
+};

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -330,3 +330,16 @@ test('jws.isValid', function (t) {
   t.same(jws.isValid(valid), true);
   t.end();
 });
+
+test('#50 mangled binary payload', function(t) {
+  const sig = jws.sign({
+    header: {
+      alg: 'HS256'
+    },
+    payload: new Buffer('TkJyotZe8NFpgdfnmgINqg==', 'base64'),
+    secret: new Buffer('8NRxgIkVxP8LyyXSL4b1dg==', 'base64')
+  });
+
+  t.same(sig, 'eyJhbGciOiJIUzI1NiJ9.TkJyotZe8NFpgdfnmgINqg.9XilaLN_sXqWFtlUCdAlGI85PCEbJZSIQpakyAle-vo');
+  t.end();
+});


### PR DESCRIPTION
binary payloads would get mangled due to the unnecessary string
conversion, which should go the other way around

Fixes: https://github.com/brianloveswords/node-jws/issues/50
