### PR TITLE
Test for invalid JSON in body

### DIFF
--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -291,6 +291,17 @@ test('jws.decode: with a bogus header ', function (t) {
   t.end();
 });
 
+test('jws.decode: with invalid json in body', function (t) {
+  const header = Buffer('{"alg":"HS256","typ":"JWT"}').toString('base64');
+  const payload = Buffer('sup').toString('base64');
+  const sig = header + '.' + payload + '.';
+  var parts;
+  t.throws(function () {
+    parts = jws.decode(sig);
+  })
+  t.end();
+});
+
 test('jws.verify: missing or invalid algorithm', function (t) {
   const header = Buffer('{"something":"not an algo"}').toString('base64');
   const payload = Buffer('sup').toString('base64');


### PR DESCRIPTION
Companion to #24, tests for the current behaviour, since some dependents (`jsonwebtoken`) may already depend on this usage, and so #24 would be a breaking change.

If #24 won't be accepted, I'll update the docs in this PR so that users know to decode in a `try/catch`, since, if they don't, they could be vulnerable to a DOS attack.