### PR TITLE
Updating base64url to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "readmeFilename": "readme.md",
   "gitHead": "c0f6b27bcea5a2ad2e304d91c2e842e4076a6b03",
   "dependencies": {
-    "base64url": "~1.0.4",
+    "base64url": "~2.0.0",
     "jwa": "^1.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "readmeFilename": "readme.md",
   "gitHead": "c0f6b27bcea5a2ad2e304d91c2e842e4076a6b03",
   "dependencies": {
-    "base64url": "~2.0.0",
+    "base64url": "^2.0.0",
     "jwa": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The base64url module changes from 1.x to 2.x only involved a rewrite to TypeScript. It appears that no tests were changed between the versions. Fixes issue #56 