### PR TITLE
raise error on undefined secrets

### DIFF
--- a/lib/sign-stream.js
+++ b/lib/sign-stream.js
@@ -26,6 +26,8 @@ function jwsSign(opts) {
 
 function SignStream(opts) {
   var secret = opts.secret||opts.privateKey||opts.key;
+  // an undefined or null secret should be an error
+  if (secret == undefined) throw new ReferenceError("secret not defined");
   var secretStream = new DataStream(secret);
   this.readable = true;
   this.header = opts.header;


### PR DESCRIPTION
Change to SignStream class as it uses DataStream objects to create secret and payload streams.  This error should then be caught by jwsSign to adequately fail users downstream instead of failing silently.