### PR TITLE
bugfix for invaild json format

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -68,7 +68,11 @@ function jwsDecode(jwsSig, opts) {
 
   var payload = payloadFromJWS(jwsSig);
   if (header.typ === 'JWT' || opts.json)
-    payload = JSON.parse(payload, opts.encoding);
+    try {
+      payload = JSON.parse(payload, opts.encoding);
+    } catch(e) {
+      return null;
+    }
 
   return {
     header: header,


### PR DESCRIPTION
if jwt token has an invalid token format then node-jwt / verify-stream.js returns the below error message:
SyntaxError: Unexpected token y in JSON at position 0
    at Object.parse (native)
    at Object.jwsDecode [as decode] (/home/brian-pc/workspace/incowiz_git/atomyair/server/http_server/node_modules/jws/lib/verify-stream.js:71:20)

this error will stop my node.js server
