### PR TITLE
Switch to maintained b64u package

### DIFF
--- a/lib/sign-stream.js
+++ b/lib/sign-stream.js
@@ -1,5 +1,5 @@
 /*global module*/
-var base64url = require('base64url');
+var base64url = require('b64u');
 var DataStream = require('./data-stream');
 var jwa = require('jwa');
 var Stream = require('stream');

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -1,5 +1,5 @@
 /*global module*/
-var base64url = require('base64url');
+var base64url = require('b64u');
 var DataStream = require('./data-stream');
 var jwa = require('jwa');
 var Stream = require('stream');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "readmeFilename": "readme.md",
   "gitHead": "c0f6b27bcea5a2ad2e304d91c2e842e4076a6b03",
   "dependencies": {
-    "base64url": "^2.0.0",
+    "b64u": "^2.0.0",
     "jwa": "^1.1.5",
     "safe-buffer": "^5.0.1"
   },


### PR DESCRIPTION
The `base64url` package has not been updated since 2016 and currently has [a critical issue](https://github.com/brianloveswords/base64url/issues/13) that prevents TypeScript users from using it with any version of Node other than v6.0.0.  This affects both the `base64url` package and all packages that depend on it, including this one.

This PR updates replaces `base64url` with `b64u`, a maintained, API-identical equivalent package.  Since the API is identical, this should require no additional changes.