### PR TITLE
Upgrade: jwa dependency from 1.1.5 -> 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "readmeFilename": "readme.md",
   "gitHead": "c0f6b27bcea5a2ad2e304d91c2e842e4076a6b03",
   "dependencies": {
-    "jwa": "^1.1.5",
+    "jwa": "^1.1.6",
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades the `jwa` dependency from `^1.1.5` to `^1.1.6` so that projects not downloading packages on a semver basis (i.e. using a `package-lock.json`) are able to benefit from the changes introduced in v1.1.6 of that package, namely:

- Dispensing with its dependency of `base64url`.
- Upgrading `ecdsa-sig-formatter` from v1.0.9 to v1.0.10, the latter of which dispenses with its dependency of `base64url`.

Vulnerabilities have been reported (by Whitesource and [Synk](https://snyk.io/vuln/npm:base64url)) in `base64url` < v3.0.0 and so we would like those versions to be excluded from our dependency tree.