### PR TITLE
Supporting a JWS token encoded with BASE64

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -6,6 +6,7 @@ var Stream = require('stream');
 var toString = require('./tostring');
 var util = require('util');
 var JWS_REGEX = /^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/;
+var JWS_REGEX_WITH_BASE64 = /^[a-zA-Z0-9\+/=]+?\.[a-zA-Z0-9\+/=]+?\.([a-zA-Z0-9\+/=]+)?$/;
 
 function isObject(thing) {
   return Object.prototype.toString.call(thing) === '[object Object]';
@@ -37,8 +38,11 @@ function payloadFromJWS(jwsSig, encoding) {
   return Buffer.from(payload, 'base64').toString(encoding);
 }
 
-function isValidJws(string) {
-  return JWS_REGEX.test(string) && !!headerFromJWS(string);
+function isValidJws(string, opts) {
+  var regex = JWS_REGEX;
+  if( opts.base64 ) 
+    regex = JWS_REGEX_WITH_BASE64;
+  return regex.test(string) && !!headerFromJWS(string);
 }
 
 function jwsVerify(jwsSig, algorithm, secretOrKey) {
@@ -58,7 +62,7 @@ function jwsDecode(jwsSig, opts) {
   opts = opts || {};
   jwsSig = toString(jwsSig);
 
-  if (!isValidJws(jwsSig))
+  if (!isValidJws(jwsSig, opts))
     return null;
 
   var header = headerFromJWS(jwsSig);

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -38,7 +38,7 @@ function payloadFromJWS(jwsSig, encoding) {
   return Buffer.from(payload, 'base64').toString(encoding);
 }
 
-function isValidJws(string, opts) {
+function isValidJws(string, opts = {}) {
   var regex = JWS_REGEX;
   if( opts.base64 ) 
     regex = JWS_REGEX_WITH_BASE64;

--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -38,7 +38,8 @@ function payloadFromJWS(jwsSig, encoding) {
   return Buffer.from(payload, 'base64').toString(encoding);
 }
 
-function isValidJws(string, opts = {}) {
+function isValidJws(string, opts) {
+  opts = opts || {};
   var regex = JWS_REGEX;
   if( opts.base64 ) 
     regex = JWS_REGEX_WITH_BASE64;


### PR DESCRIPTION
Currently, AWS ALB makes a JWT token with base64 (not base64url encoding).
Since node-jws very strictly checks the format of a token, the JWT token made by ALB cannot pass verification. 
As a workaround, I added an option "base64". 
If the "base64" option is true, characters used in the base64 encoding are checked instead of it of the base64url encoding.
