### PR TITLE
jws.decode support for encoding option

### DIFF
--- a/lib/verify-stream.js
+++ b/lib/verify-stream.js
@@ -66,7 +66,7 @@ function jwsDecode(jwsSig, opts) {
   if (!header)
     return null;
 
-  var payload = payloadFromJWS(jwsSig);
+  var payload = payloadFromJWS(jwsSig, opts.encoding);
   if (header.typ === 'JWT' || opts.json)
     payload = JSON.parse(payload, opts.encoding);
 

--- a/test/jws.test.js
+++ b/test/jws.test.js
@@ -343,3 +343,11 @@ test('#50 mangled binary payload', function(t) {
   t.same(sig, 'eyJhbGciOiJIUzI1NiJ9.TkJyotZe8NFpgdfnmgINqg.9XilaLN_sXqWFtlUCdAlGI85PCEbJZSIQpakyAle-vo');
   t.end();
 });
+
+test('jws.decode supports encoding option', function (t) {
+  const payloadString = 'åäöí';
+  const jwsObj = jws.sign({ header: { alg: 'hs256' }, payload: payloadString, secret: 'shhh', encoding: "latin1" });
+  const parts = jws.decode(jwsObj, {encoding: "latin1"});
+  t.same(parts.payload, payloadString, 'should match payload');
+  t.end();
+});


### PR DESCRIPTION
`jws.sign` supports specifying encoding but `jws.decode` doesn't (although the `payloadFromJWS` function has an unused `encoding` parameter). This pull request aims to fix this.